### PR TITLE
chore: fix python3 example/color.py'

### DIFF
--- a/examples/color.py
+++ b/examples/color.py
@@ -2,14 +2,14 @@ def print_format_table():
     """
     prints table of formatted text format options
     """
-    for style in xrange(8):
-        for fg in xrange(30, 38):
+    for style in range(8):
+        for fg in range(30, 38):
             s1 = ''
-            for bg in xrange(40, 48):
+            for bg in range(40, 48):
                 format = ';'.join([str(style), str(fg), str(bg)])
                 s1 += '\x1b[%sm %s \x1b[0m' % (format, format)
-            print s1
-        print '\n'
+            print(s1)
+        print('\n')
 
 print("BEFORE")
 


### PR DESCRIPTION
The file "color.py" in the directory "examples" uses mixed syntax. I fixed Python2 code in Python3