### PR TITLE
Can cooperate with Terminus (allows inputs)

### DIFF
--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -49,8 +49,6 @@ export default class Runtime {
   // * "File Based"
   // input (Optional) - {String} that'll be provided to the `stdin` of the new process
   execute(argType = 'Selection Based', input = null, options = null) {
-    if (atom.config.get('script.stopOnRerun')) this.stop();
-    this.emitter.emit('start');
 
     const codeContext = this.codeContextBuilder.buildCodeContext(
       atom.workspace.getActiveTextEditor(), argType);
@@ -61,6 +59,26 @@ export default class Runtime {
 
     const executionOptions = !options ? this.scriptOptions : options;
     const commandContext = CommandContext.build(this, executionOptions, codeContext);
+
+
+    // Will cooperate with Terminus to allow for inputs, if user has installed.
+    try {
+      var terminus = require('../../terminus/lib/terminus.js').provideTerminus();
+    } catch (e) {
+      var terminus = null;
+      console.log("Could not find Terminus");
+    }
+    if (terminus != null) {
+       var command = commandContext.command;
+       for (let i = 0; i < commandContext.args.length; i++) {
+         command += ' "' + commandContext.args[i] + '"';
+       }
+       terminus.run(['printf "\\33c\\e[3J" && ' + command]);
+       return;
+     }
+
+    if (atom.config.get('script.stopOnRerun')) this.stop();
+    this.emitter.emit('start');
 
     if (!commandContext) return;
 


### PR DESCRIPTION
To solve a common 'problem' seen by users regarding inputs not working, send commands from Script to [Terminus](https://atom.io/packages/terminus) to run rather than Atom's Buffered Process. Code is run in Terminus' internal terminal window and allows for Input (If Terminus not installed, returns to default behaviour).